### PR TITLE
Force sphinx to document class __init__ as well as class docstrings

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -43,6 +43,7 @@ extensions = ['sphinx.ext.autodoc',
 templates_path = ['_templates']
 
 autodoc_member_order = 'bysource'
+autoclass_content = 'both'
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:


### PR DESCRIPTION
- 