### PR TITLE
Fixed ternary volume expansion approach 

### DIFF
--- a/matador/plotting/battery_plotting.py
+++ b/matador/plotting/battery_plotting.py
@@ -131,7 +131,7 @@ def _add_voltage_curve(capacities, voltages, ax_volt, label=None, **kwargs):
 
 
 @plotting_function
-def plot_volume_curve(hull, ax=None, show=False, **kwargs):
+def plot_volume_curve(hull, ax=None, show=True, legend=False, **kwargs):
     """ Plot volume curve calculated for phase diagram.
 
     Parameters:
@@ -154,33 +154,15 @@ def plot_volume_curve(hull, ax=None, show=False, **kwargs):
     else:
         ax = ax
 
-    for j in range(len(hull.volume_data['vol_per_y'])):
+    for j in range(len(hull.volume_data['electrode_volume'])):
         stable_hull_dist = hull.volume_data['hull_distances'][j]
         if len(stable_hull_dist) != len(hull.volume_data['Q'][j]):
             raise RuntimeError("This plot does not support --hull_cutoff.")
-        for i in range(len(hull.volume_data['vol_per_y'][j])):
-            if stable_hull_dist[i] <= 0 + 1e-16:
-                s = 40
-                zorder = 1000
-                markeredgewidth = 1.5
-                c = hull.colours[1]
-                alpha = 1
-            else:
-                s = 30
-                zorder = 900
-                alpha = 0.3
-                markeredgewidth = 0
-                c = 'grey'
-
-            ax.scatter(hull.volume_data['Q'][j][i],
-                       hull.volume_data['volume_ratio_with_bulk'][j][i],
-                       marker='o', s=s, edgecolor='k',
-                       lw=markeredgewidth, c=c, zorder=zorder, alpha=alpha)
 
         ax.plot(
             [q for ind, q in enumerate(hull.volume_data['Q'][j][:-1]) if stable_hull_dist[ind] == 0],
             [v for ind, v in enumerate(hull.volume_data['volume_ratio_with_bulk'][j]) if stable_hull_dist[ind] == 0],
-            marker=None,
+            marker='o', markeredgewidth=1.5, markeredgecolor='w',
             zorder=100,
             label=("Volume expansion from bulk {}"
                    .format(get_formula_from_stoich(hull.volume_data['endstoichs'][j], tex=True)))
@@ -188,7 +170,8 @@ def plot_volume_curve(hull, ax=None, show=False, **kwargs):
 
     ax.set_xlabel("Gravimetric capacity (mAh/g)")
     ax.set_ylabel('Volume ratio with starting electrode')
-    ax.legend()
+    if legend or len(hull.volume_data['Q']) > 1:
+        ax.legend()
     fname = '{}_volume'.format(''.join(hull.elements))
 
     if hull.savefig or any([kwargs.get(ext) for ext in SAVE_EXTS]):

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -427,7 +427,7 @@ class VolumeTest(unittest.TestCase):
         hull.volume_curve()
         self.assertEqual(len(hull.volume_data["x"][0]), len(hull.hull_cursor) - 1)
         self.assertEqual(
-            len(hull.volume_data["vol_per_y"][0]), len(hull.hull_cursor) - 1
+            len(hull.volume_data["electrode_volume"][0]), len(hull.hull_cursor) - 1
         )
 
     def test_ternary_volume_curve(self):
@@ -480,10 +480,10 @@ class VolumeTest(unittest.TestCase):
         )
 
         np.testing.assert_array_almost_equal(
-            hull.volume_data["vol_per_y"][0], [10.0, 0.75 * 21.0 / 2 + 0.25 * 10]
+            hull.volume_data["electrode_volume"][0], [30, 31]
         )
         np.testing.assert_array_almost_equal(
-            hull.volume_data["volume_ratio_with_bulk"][0], [1, 1.0375]
+            hull.volume_data["volume_ratio_with_bulk"][0], [1, 31/30]
         )
 
         cursor = [
@@ -535,8 +535,8 @@ class VolumeTest(unittest.TestCase):
         )
 
         np.testing.assert_array_almost_equal(
-            hull.volume_data["vol_per_y"][0], [5.0, 0.75 * 21.0 / 2 + 0.25 * 10]
+            hull.volume_data["electrode_volume"][0], [15, 31]
         )
         np.testing.assert_array_almost_equal(
-            hull.volume_data["volume_ratio_with_bulk"][0], [1, 2 * 1.0375]
+            hull.volume_data["volume_ratio_with_bulk"][0], [1, 31/15]
         )


### PR DESCRIPTION
The previous approach to volume expansions only worked accidentally and relied on some fortuitous error cancellation between the number of formula units in the starting electrode and those in the final phases. This fixes that by explicitly working with the cell volume per fu of the starting electrode, and by balancing all reactions leading up to the final state.