### PR TITLE
Patch for multi-node MPI and refactored compute

### DIFF
--- a/matador/compute/__init__.py
+++ b/matador/compute/__init__.py
@@ -4,12 +4,12 @@
 """ The compute module contains three submodules, compute, batch and
 slurm.
 
-The compute submodule contains the FullRelaxer class for performing
+The compute submodule contains the :class:`ComputeTask` class for performing
 continually restarted geometry optimisation and SCF calculations in
 CASTEP, as well as the execution of arbitrary programs with mpirun.
 
-The batch submodule contains the BatchRun class for running several
-independent FullRelaxer instances on a folder of structures, without
+The batch submodule contains the :class:`BatchRun` class for running several
+independent :class:`ComputeTask` instances on a folder of structures, without
 clashes.
 
 The slurm submodule provides a wrapper to useful slurm commands, and to
@@ -18,10 +18,10 @@ writing slurm job submission files.
 """
 
 
-__all__ = ['ComputeTask', 'BatchRun', 'reset_job_folder', 'FullRelaxer']
+__all__ = ['ComputeTask', 'BatchRun', 'reset_job_folder']
 __author__ = 'Matthew Evans'
 __maintainer__ = 'Matthew Evans'
 
 
-from matador.compute.compute import FullRelaxer, ComputeTask
+from matador.compute.compute import ComputeTask
 from matador.compute.batch import BatchRun, reset_job_folder

--- a/matador/workflows/castep/elastic.py
+++ b/matador/workflows/castep/elastic.py
@@ -22,7 +22,7 @@ def castep_elastic(relaxer, calc_doc, seed, **kwargs):
     Currently only calculation of the bulk modulus is implemented.
 
     Parameters:
-        relaxer (:obj:`FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): dictionary of structure and calculation
             parameters.
         seed (str): root seed for the calculation.
@@ -45,7 +45,7 @@ class CastepElasticWorkflow(Workflow):
     of DOS.
 
     Attributes:
-        relaxer (:obj:`FullRelaxer`): the object that calls CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that calls CASTEP.
         calc_doc (dict): the interim dictionary of structural and
             calculation parameters.
         seed (str): the root seed for the calculation.
@@ -90,7 +90,7 @@ def castep_rescaled_volume_scf(relaxer, calc_doc, seed, rescale=1):
     """ Run a singleshot SCF calculation.
 
     Parameters:
-        relaxer (:obj:`FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -108,14 +108,14 @@ def castep_rescaled_volume_scf(relaxer, calc_doc, seed, rescale=1):
     bulk_mod_seed = seed + '.bulk_mod'
     relaxer.seed = bulk_mod_seed
 
-    return relaxer.scf(scf_doc, bulk_mod_seed, keep=True, intermediate=True)
+    return relaxer.run_castep_singleshot(scf_doc, bulk_mod_seed, keep=True, intermediate=True)
 
 
 def castep_elastic_prerelax(relaxer, calc_doc, seed):
     """ Run a geometry optimisation before re-scaling volumes SCF-style calculation.
 
     Parameters:
-        relaxer (:obj:`FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -131,4 +131,4 @@ def castep_elastic_prerelax(relaxer, calc_doc, seed):
     relaxer.validate_calc_doc(relax_doc, required, forbidden)
     relaxer.calc_doc = relax_doc
 
-    return relaxer.relax(intermediate=True)
+    return relaxer.run_castep_relaxation(intermediate=True)

--- a/matador/workflows/castep/phonons.py
+++ b/matador/workflows/castep/phonons.py
@@ -35,7 +35,7 @@ def castep_full_phonon(relaxer, calc_doc, seed, **kwargs):
     is a wrapper for the CastepPhononWorkflow class.
 
     Parameters:
-        relaxer (:obj:`FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): dictionary of structure and calculation
             parameters.
         seed (str): root seed for the calculation.
@@ -58,7 +58,7 @@ class CastepPhononWorkflow(Workflow):
     that dynamical matrix into dispersion curves and DOS.
 
     Attributes:
-        relaxer (:obj:`FullRelaxer`): the object that calls CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that calls CASTEP.
         calc_doc (dict): the interim dictionary of structural and
             calculation parameters.
         seed (str): the root seed for the calculation.
@@ -147,7 +147,7 @@ def castep_phonon_prerelax(relaxer, calc_doc, seed):
     The phonon calculation will then be restarted from the .check file produced here.
 
     Parameters:
-        relaxer (:obj:`FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -168,14 +168,14 @@ def castep_phonon_prerelax(relaxer, calc_doc, seed):
     relaxer.validate_calc_doc(relax_doc, required, forbidden)
     relaxer.calc_doc = relax_doc
 
-    relaxer.relax(intermediate=True)
+    relaxer.run_castep_relaxation(intermediate=True)
 
 
 def castep_phonon_dynmat(relaxer, calc_doc, seed):
     """ Runs a singleshot phonon dynmat calculation, with no "fine_method" interpolation.
 
     Parameters:
-        relaxer (:obj:`FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -192,7 +192,7 @@ def castep_phonon_dynmat(relaxer, calc_doc, seed):
                  'phonon_fine_kpoint_path_spacing']
 
     relaxer.validate_calc_doc(dynmat_doc, required, forbidden)
-    return relaxer.scf(dynmat_doc, seed, keep=True, intermediate=True)
+    return relaxer.run_castep_singleshot(dynmat_doc, seed, keep=True, intermediate=True)
 
 
 def castep_phonon_dos(relaxer, calc_doc, seed):
@@ -200,7 +200,7 @@ def castep_phonon_dos(relaxer, calc_doc, seed):
     phonon calculation.
 
     Parameters:
-        relaxer (:obj:`FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -218,7 +218,7 @@ def castep_phonon_dos(relaxer, calc_doc, seed):
 
     relaxer.validate_calc_doc(dos_doc, required, forbidden)
 
-    return relaxer.scf(dos_doc, seed, keep=True, intermediate=True)
+    return relaxer.run_castep_singleshot(dos_doc, seed, keep=True, intermediate=True)
 
 
 def castep_phonon_dispersion(relaxer, calc_doc, seed):
@@ -226,7 +226,7 @@ def castep_phonon_dispersion(relaxer, calc_doc, seed):
     phonon calculation.
 
     Parameters:
-        relaxer (:obj:`FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -242,7 +242,7 @@ def castep_phonon_dispersion(relaxer, calc_doc, seed):
 
     relaxer.validate_calc_doc(disp_doc, required, forbidden)
 
-    return relaxer.scf(disp_doc, seed, keep=True, intermediate=True)
+    return relaxer.run_castep_singleshot(disp_doc, seed, keep=True, intermediate=True)
 
 
 def castep_phonon_thermodynamics(relaxer, calc_doc, seed):
@@ -250,7 +250,7 @@ def castep_phonon_thermodynamics(relaxer, calc_doc, seed):
     phonon calculation, using the phonon_fine_kpoint_mp_grid.
 
     Parameters:
-        relaxer (:obj:`FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -268,4 +268,4 @@ def castep_phonon_thermodynamics(relaxer, calc_doc, seed):
 
     relaxer.validate_calc_doc(thermo_doc, required, forbidden)
 
-    return relaxer.scf(thermo_doc, seed, keep=True, intermediate=True)
+    return relaxer.run_castep_singleshot(thermo_doc, seed, keep=True, intermediate=True)

--- a/matador/workflows/castep/spectral.py
+++ b/matador/workflows/castep/spectral.py
@@ -32,7 +32,7 @@ def castep_full_spectral(relaxer, calc_doc, seed, **kwargs):
     of DOS.
 
     Parameters:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): dictionary of structure and calculation
             parameters.
         seed (str): root seed for the calculation.
@@ -55,7 +55,7 @@ class CastepSpectralWorkflow(Workflow):
     of DOS.
 
     Attributes:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that calls CASTEP.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that calls CASTEP.
         calc_doc (dict): the interim dictionary of structural and
             calculation parameters.
         seed (str): the root seed for the calculation.
@@ -176,7 +176,7 @@ def castep_spectral_scf(relaxer, calc_doc, seed):
     """ Run a singleshot SCF calculation.
 
     Parameters:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -198,7 +198,7 @@ def castep_spectral_scf(relaxer, calc_doc, seed):
 
     relaxer.validate_calc_doc(scf_doc, required, forbidden)
 
-    return relaxer.scf(scf_doc, seed, keep=True, intermediate=True)
+    return relaxer.run_castep_singleshot(scf_doc, seed, keep=True, intermediate=True)
 
 
 def castep_spectral_dos(relaxer, calc_doc, seed):
@@ -206,7 +206,7 @@ def castep_spectral_dos(relaxer, calc_doc, seed):
     .odi file is found, run OptaDOS on the resulting DOS.
 
     Parameters:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -227,7 +227,7 @@ def castep_spectral_dos(relaxer, calc_doc, seed):
                  'spectral_kpoints_path_spacing']
 
     relaxer.validate_calc_doc(dos_doc, required, forbidden)
-    success = relaxer.scf(dos_doc, seed, keep=True, intermediate=True)
+    success = relaxer.run_castep_singleshot(dos_doc, seed, keep=True, intermediate=True)
 
     return success
 
@@ -237,7 +237,7 @@ def castep_spectral_dispersion(relaxer, calc_doc, seed):
     optionally running orbitals2bands and OptaDOS projected dispersion.
 
     Parameters:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be calling CASTEP.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that will be calling CASTEP.
         calc_doc (dict): the structure to run on.
         seed (str): root filename of structure.
 
@@ -257,7 +257,7 @@ def castep_spectral_dispersion(relaxer, calc_doc, seed):
     forbidden = ['spectral_kpoints_mp_spacing']
 
     relaxer.validate_calc_doc(disp_doc, required, forbidden)
-    success = relaxer.scf(disp_doc, seed, keep=True, intermediate=True)
+    success = relaxer.run_castep_singleshot(disp_doc, seed, keep=True, intermediate=True)
 
     if disp_doc.get('write_orbitals'):
         LOG.info('Planning to call orbitals2bands...')
@@ -283,7 +283,7 @@ def optados_pdos(relaxer, _, seed):
     """ Run an OptaDOS projected-DOS.
 
     Parameters:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be calling OptaDOS.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that will be calling OptaDOS.
         _ : second parameter is required but ignored.
         seed (str): root filename of structure.
 
@@ -308,7 +308,7 @@ def optados_dos_broadening(relaxer, _, seed):
     """ Run an OptaDOS total DOS broadening.
 
     Parameters:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be calling OptaDOS.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that will be calling OptaDOS.
         _ : second parameter is required but ignored.
         seed (str): root filename of structure.
 
@@ -334,7 +334,7 @@ def optados_pdispersion(relaxer, _, seed):
     """ Runs an OptaDOS projected dispersion calculation.
 
     Parameters:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be calling OptaDOS.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that will be calling OptaDOS.
         _ : second parameter is required but ignored.
         seed (str): root filename of structure.
 
@@ -358,7 +358,7 @@ def _run_optados(relaxer, odi_dict, seed, suffix=None):
     the number of cores and the executable to call, then restoring them after.
 
     Parameters:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be calling OptaDOS.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that will be calling OptaDOS.
         odi_dict (dict): the OptaDOS parameters to write to file.
         seed (str): root filename of structure.
 

--- a/matador/workflows/workflows.py
+++ b/matador/workflows/workflows.py
@@ -17,13 +17,13 @@ LOG = logging.getLogger('run3')
 class Workflow:
     """ Workflow objects are bundles of calculations defined as
     :obj:`WorkflowStep` objects. Each :obj:`WorkflowStep` takes three arguments:
-    the :obj:`matador.compute.FullRelaxer` object used to run the calculations, the calculation
+    the :obj:`matador.compute.ComputeTask` object used to run the calculations, the calculation
     parameters (which can be modified by each step), the seed name.
     Any subclass of Workflow must implement `preprocess` and `postprocess`
     methods (even if they just return True).
 
     Attributes:
-        relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be running the computation.
+        relaxer (:obj:`matador.compute.ComputeTask`): the object that will be running the computation.
         calc_doc (dict): the interim dictionary of structural and
             calculation parameters.
         seed (str): the root seed for the calculation.
@@ -35,11 +35,11 @@ class Workflow:
 
     """
     def __init__(self, relaxer, calc_doc, seed, **workflow_kwargs):
-        """ Initialise the Workflow object from a :obj:`matador.compute.FullRelaxer`, calculation
+        """ Initialise the Workflow object from a :obj:`matador.compute.ComputeTask`, calculation
         parameters and the seed name.
 
         Parameters:
-            relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be running the computation.
+            relaxer (:obj:`matador.compute.ComputeTask`): the object that will be running the computation.
             calc_doc (dict): dictionary of structure and calculation
                 parameters.
             seed (str): root seed for the calculation.
@@ -260,7 +260,7 @@ class WorkflowStep:
         """ Run the workflow step.
 
         Parameters:
-            relaxer (:obj:`matador.compute.FullRelaxer`): the object that will be running the computation.
+            relaxer (:obj:`matador.compute.ComputeTask`): the object that will be running the computation.
             calc_doc (dict): dictionary of structure and calculation
                 parameters.
             seed (str): root seed for the calculation.


### PR DESCRIPTION
This PR fixes #30 but replacing previous pure `.poll()` calls with `.communicate()`. For some reason, multi-node MPI processes always return `None` to `.poll()`, even if they have successfully returned.

This PR also refactors `ComputeTask` to be a bit cleaner and deprecates some old class names.