### PR TITLE
Spectral plot tweaks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,9 @@ coverage:
   range: "50...80"
 
   status:
-    project: yes
-    patch: yes
-    changes: no
-    threshold: 1
+    project:
+        threshold: 0.05
+    patch:
+        threshold: 100
+    changes:
+        threshold: 50

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,9 +8,6 @@ coverage:
   range: "50...80"
 
   status:
-    project:
-        threshold: 0.05
-    patch:
-        threshold: 100
-    changes:
-        threshold: 50
+    project: off
+    patch: off
+    changes: off

--- a/matador/cli/dispersion.py
+++ b/matador/cli/dispersion.py
@@ -44,8 +44,6 @@ def main():
                         help='plot PDOS as overlap rather than stack')
     parser.add_argument('--no_pdis', action='store_true',
                         help='do not try to plot PDIS, even if its available')
-    parser.add_argument('--no_band_reorder', action='store_true',
-                        help='don\'t reorder bands based on local gradients')
     parser.add_argument('--band_reorder', action='store_true',
                         help='try to reorder bands based on local gradients')
     parser.add_argument('--pdos_hide_tot', action='store_true',
@@ -103,15 +101,8 @@ def main():
     del kwargs['no_pdis']
 
     cmap = kwargs.get('cmap')
-    band_colour = kwargs.get('band_colour')
-    if band_colour is None:
-        band_colour = 'occ'
-    if kwargs['no_band_reorder']:
-        band_reorder = False
-    elif kwargs['band_reorder']:
-        band_reorder = True
-    else:
-        band_reorder = None
+    band_colour = kwargs.get('band_colour', 'occ')
+    band_reorder = kwargs.get('band_reorder', False)
 
     from matador.plotting import plot_spectral, plot_ir_spectrum
 
@@ -121,9 +112,10 @@ def main():
     del kwargs['cmap']
     del kwargs['band_colour']
     del kwargs['band_reorder']
-    del kwargs['no_band_reorder']
 
     bandstructure = False
+    dos = False
+
     for seed in seeds:
         if not phonons and not ir:
             bs_seed = seed + '.bands'
@@ -155,6 +147,9 @@ def main():
 
     if kwargs.get('bs_only') and bandstructure:
         dos = False
+
+    if not any([bandstructure, dos, ir]):
+        raise SystemExit("Unable to find files for seedname {}".format(seed))
 
     if not ir:
         return plot_spectral(

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -124,6 +124,7 @@ class SpectralPlotTests(unittest.TestCase):
             "--cmap",
             "viridis",
             "--png",
+            "--band_reorder",
             "--labels",
             "PBE, LDA",
             "--figsize",


### PR DESCRIPTION
Closes #39 by preventing multiple band reorderings to occur, and also disables band reordering for phonons by default.

Additional changes:
- Adds `cmap` and `band_alpha` as args to spectral plotter
- Fixes issue where empty plot would be created if files were missing
- Changed default phonon spectral plot to use slightly transparent grey bands
- Tweaked codecov settings so that they dont mark a branch as red when coverage has changed by 0.01%... 