### PR TITLE
Fix misreported core count with hyperthreading

### DIFF
--- a/matador/compute/batch.py
+++ b/matador/compute/batch.py
@@ -14,6 +14,7 @@ import os
 import glob
 import time
 import random
+import psutil
 from matador.utils.print_utils import print_failure, print_warning
 from matador.compute.queueing import get_queue_manager
 from matador.scrapers.castep_scrapers import cell2dict, param2dict
@@ -124,7 +125,7 @@ class BatchRun:
             self.start_time = time.time()
 
         # assign number of cores
-        self.all_cores = mp.cpu_count()
+        self.all_cores = psutil.cpu_count(logical=False)
         if self.args.get('ncores') is None:
             if self.queue_mgr is None:
                 self.args['ncores'] = int(self.all_cores / self.nprocesses)

--- a/matador/fingerprints/fingerprint.py
+++ b/matador/fingerprints/fingerprint.py
@@ -17,6 +17,7 @@ import time
 import sys
 import functools
 
+import psutil
 import numba
 import numpy as np
 
@@ -130,7 +131,7 @@ class FingerprintFactory(abc.ABC):
     Note:
         The number of processes used to concurrency is set by the following
         hierarchy:
-        SLURM_NTASKS -> OMP_NUM_THREADS -> multiprocessing.cpu_count().
+        SLURM_NTASKS -> OMP_NUM_THREADS -> `psutil.cpu_count(logical=False)`.
 
     Attributes:
         nprocs (int): number of concurrent processes to be used.
@@ -186,7 +187,7 @@ class FingerprintFactory(abc.ABC):
             self.nprocs = int(os.environ.get('OMP_NUM_THREADS'))
             env = '$OMP_NUM_THREADS'
         else:
-            self.nprocs = mp.cpu_count()
+            self.nprocs = psutil.cpu_count(logical=False)
             env = 'core count'
         print_notify('Running {} jobs on at most {} processes, set by {}.'
                      .format(len(required_inds), self.nprocs, env))

--- a/scripts/oddjob
+++ b/scripts/oddjob
@@ -11,6 +11,8 @@ import argparse
 import multiprocessing as mp
 import subprocess as sp
 from os import getcwd
+import psutil
+
 from matador.utils.print_utils import print_notify, print_warning
 
 
@@ -44,7 +46,7 @@ class Hive:
     def run_command(self, node):
         """ Parse command and run on particular node. """
         cwd = getcwd()
-        compute_command = self.command.replace('$ALL_CORES', str(mp.cpu_count()))
+        compute_command = self.command.replace('$ALL_CORES', str(psutil.cpu_count(logical=False)))
         print_notify('Executing {} on {}{}...'.format(compute_command, self.prefix, node))
         process = sp.Popen(['ssh', '{}{}'.format(self.prefix, node),
                             'cd', '{};'.format(cwd),

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -12,6 +12,8 @@ import time
 import warnings
 import multiprocessing as mp
 
+import psutil
+
 from matador.utils.errors import (
     CalculationError,
     MaxMemoryEstimateExceeded,
@@ -40,7 +42,7 @@ CASTEP_PRESENT = detect_program(EXECUTABLE)
 MPI_PRESENT = detect_program("mpirun")
 
 if CASTEP_PRESENT and MPI_PRESENT:
-    NCORES = max(mp.cpu_count() - 2, 1)
+    NCORES = max(psutil.cpu_count(logical=False) - 2, 1)
 else:
     NCORES = 1
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -4,10 +4,10 @@
 
 import unittest
 import os
-import multiprocessing as mp
 import shutil
 import glob
 
+import psutil
 import numpy as np
 
 from .utils import MatadorUnitTest, REAL_PATH, detect_program
@@ -25,7 +25,7 @@ CASTEP_PRESENT = detect_program(EXECUTABLE)
 MPI_PRESENT = detect_program("mpirun")
 
 if CASTEP_PRESENT and MPI_PRESENT:
-    NCORES = mp.cpu_count() - 2
+    NCORES = max(psutil.cpu_count(logical=False) - 2, 1)
 else:
     NCORES = 1
 


### PR DESCRIPTION
Use `psutil.cpu_count(logical=False)` instead of `multiprocessing.cpu_count()` to ignore hyperthreading.