### PR TITLE
Minor fixes

### DIFF
--- a/matador/orm/orm.py
+++ b/matador/orm/orm.py
@@ -8,6 +8,7 @@ children.
 """
 
 import copy
+import math
 from abc import ABC
 
 
@@ -88,7 +89,13 @@ class DataContainer(ABC):
     def __setitem__(self, key: str, item):
         if key not in self._data or self._data[key] is None:
             self._data[key] = item
+            return
         elif self._data[key] != item:
+            try:
+                if (math.isnan(item) and math.isnan(self._data[key])):
+                    return
+            except TypeError:
+                pass
             raise AttributeError('Cannot assign value {} to existing key {} with value {}'
                                  .format(item, key, self._data[key]))
 

--- a/matador/utils/cursor_utils.py
+++ b/matador/utils/cursor_utils.py
@@ -167,13 +167,14 @@ def display_results(cursor,
     if sort and isinstance(cursor, pm.cursor.Cursor):
         print("Unable to check sorting of cursor, assuming it is already sorted.")
     elif sort:
-        sorted_inds = sorted(list(enumerate(cursor)),
+        sorted_inds = sorted(enumerate(cursor),
                              key=lambda element: recursive_get(element[1], energy_key))
-        cursor = [cursor[ind[0]] for ind in sorted_inds]
+        cursor = [ind[1] for ind in sorted_inds]
+        sorted_inds = [ind[0] for ind in sorted_inds]
         if additions is not None and add_index_mode:
-            additions = [sorted_inds[ind][0] for ind in additions]
+            additions = [sorted_inds.index(ind) for ind in additions]
         if deletions is not None and del_index_mode:
-            deletions = [sorted_inds[ind][0] for ind in deletions]
+            deletions = [sorted_inds.index(ind) for ind in deletions]
 
     # loop over structures and create pretty output
     for ind, doc in enumerate(cursor):

--- a/tests/test_crystal.py
+++ b/tests/test_crystal.py
@@ -82,6 +82,27 @@ class CrystalTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             crystal["positions_frac"] = [[0, 1, 2]]
 
+        # check we can set fields to the same value
+        crystal["new_field"] = [1, 2, 3]
+        crystal["new_field"] = [1, 2, 3]
+
+        crystal["new_field_2"] = np.nan
+        crystal["new_field_2"] = np.nan
+
+        crystal["new_field_3"] = [1, 2, 4]
+        with self.assertRaises(AttributeError):
+            crystal["new_field_3"] = [1, 2, 5]
+
+        crystal["new_field_4"] = [1, 2, np.nan]
+        crystal["new_field_4"] = [1, 2, np.nan]
+
+        crystal["new_field_5"] = [1, np.nan, 2]
+        with self.assertRaises(AttributeError):
+            crystal["new_field_5"] = [1, 2, np.nan]
+
+        crystal["new_field_6"] = np.linspace(0, 1, 1000).tolist()
+        crystal["new_field_6"] = np.array(crystal["new_field_6"], copy=True).tolist()
+
     def test_set_positions(self):
         doc, s = castep2dict(REAL_PATH + "data/Na3Zn4-swap-ReOs-OQMD_759599.castep")
         doc = Crystal(doc)


### PR DESCRIPTION
- Fixed issue where incorrect additions/deletions would be displayed when filtering for uniqueness, depending on sorting of initial cursor. This did not effect which structueres were actually filtered.
- Allow fields of `Crystal` to be set by NaN values, if they were NaN previously.