### PR TITLE
v0.9.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+New in release (0.9.2) [01/06/2020]
+-----------------------------------
+
+- Optimised CIF reader considerably (#50)
+- Updated PXRD calculator to allow for partial occupancy, monochromated beam angles and text export, and added ``pxrd_calculator`` script for convenience when handling CIF files.
+- Added ability to choose which projectors are plotted with dispersion (#47)
+- Various minor fixes and updates:
+
+    - Updates to docs for CLI and configuration.
+    - Allow nan-values to be reset inside :class:`matador.crystal.Crystal`.
+    - Fixed display ordering of fingerprint-filtered cursors.
+
+
 New in release (0.9.1) [20/05/2020]
 -----------------------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,9 @@
 recursive-include matador/config *
 recursive-include docs *
-recursive-include matador/tests/data *
-recursive-include matador/data *
+recursive-include matador/data/atomic_scattering *.dat
 recursive-include requirements/ *
+include matador/data/nouns
+include matador/data/words
 include README.rst
 include CHANGELOG.rst
 include INSTALL.rst

--- a/matador/__init__.py
+++ b/matador/__init__.py
@@ -11,7 +11,6 @@ theory compute engines.
 __all__ = ['__version__']
 __author__ = 'Matthew Evans'
 __maintainer__ = 'Matthew Evans'
-
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 script_epilog = f"Written and maintained by Matthew Evans (me388@cam.ac.uk) 2016-2020, version {__version__}."

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open('requirements/pip_requirements.txt', 'r') as f:
 extra_requirements = dict(all=[])
 req_files = glob('requirements/*.txt')
 for _file in req_files:
-    if _file != 'requirements/requirements.txt':
+    if _file not in ['requirements/requirements.txt', 'requirements/pip_requirements.txt']:
         with open(_file, 'r') as f:
             subreq = _file.split('/')[-1].split('_')[0]
             extra_requirements[subreq] = [line.strip() for line in f.readlines()]

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,11 @@
+""" Some tasks for deployment to PyPI/TestPyPI. """
+
+
+from invoke import task
+
+
+@task
+def publish_to_pypi(c, test=False):
+    c.run("rm -rf build dist", warn=True)
+    c.run("python setup.py sdist bdist_wheel")
+    c.run("twine upload --verbose dist/*" + " --repository-url https://test.pypi.org/legacy/" if test else "")


### PR DESCRIPTION
Minor release with following changes:

- Optimised CIF reader considerably (#50)
- Updated PXRD calculator to allow for partial occupancy, monochromated beam angles and text export, and added ``pxrd_calculator`` script for convenience when handling CIF files (#50)
- Added ability to choose which projectors are plotted with dispersion (#47)
- Various minor fixes and updates:

    - Updates to docs for CLI and configuration.
    - Allow nan-values to be reset inside :class:`matador.crystal.Crystal`.
    - Fixed display ordering of fingerprint-filtered cursors.