### PR TITLE
v0.9.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+New in release (0.9.3) [07/06/2020]
+-----------------------------------
+
+- Fixes for the CIF reader: now works with awkward linebreaks and alternative symmetry operation specifications (#61).
+- Added several new flags to ``pxrd_calculator`` script (#60 and 61).
+- Usability fixes for ``spectral_plotting`` in the case of projected dispersion curves (#59).
+
 New in release (0.9.2) [01/06/2020]
 -----------------------------------
 

--- a/matador/__init__.py
+++ b/matador/__init__.py
@@ -11,6 +11,6 @@ theory compute engines.
 __all__ = ['__version__']
 __author__ = 'Matthew Evans'
 __maintainer__ = 'Matthew Evans'
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 script_epilog = f"Written and maintained by Matthew Evans (me388@cam.ac.uk) 2016-2020, version {__version__}."


### PR DESCRIPTION
- Fixes for the CIF reader: now works with awkward linebreaks and alternative symmetry operation specifications (#61).
- Added several new flags to ``pxrd_calculator`` script (#60 and 61).
- Usability fixes for ``spectral_plotting`` in the case of projected dispersion curves (#59).