### PR TITLE
Revert cpu_count change to work on dual-socket, non-hyperthreaded machines

### DIFF
--- a/matador/compute/batch.py
+++ b/matador/compute/batch.py
@@ -125,7 +125,7 @@ class BatchRun:
             self.start_time = time.time()
 
         # assign number of cores
-        self.all_cores = psutil.cpu_count(logical=False)
+        self.all_cores = psutil.cpu_count(logical=True)
         if self.args.get('ncores') is None:
             if self.queue_mgr is None:
                 self.args['ncores'] = int(self.all_cores / self.nprocesses)

--- a/matador/fingerprints/fingerprint.py
+++ b/matador/fingerprints/fingerprint.py
@@ -131,7 +131,7 @@ class FingerprintFactory(abc.ABC):
     Note:
         The number of processes used to concurrency is set by the following
         hierarchy:
-        SLURM_NTASKS -> OMP_NUM_THREADS -> `psutil.cpu_count(logical=False)`.
+        SLURM_NTASKS -> OMP_NUM_THREADS -> `psutil.cpu_count(logical=True)`.
 
     Attributes:
         nprocs (int): number of concurrent processes to be used.
@@ -187,7 +187,7 @@ class FingerprintFactory(abc.ABC):
             self.nprocs = int(os.environ.get('OMP_NUM_THREADS'))
             env = '$OMP_NUM_THREADS'
         else:
-            self.nprocs = psutil.cpu_count(logical=False)
+            self.nprocs = psutil.cpu_count(logical=True)
             env = 'core count'
         print_notify('Running {} jobs on at most {} processes, set by {}.'
                      .format(len(required_inds), self.nprocs, env))

--- a/scripts/oddjob
+++ b/scripts/oddjob
@@ -46,7 +46,7 @@ class Hive:
     def run_command(self, node):
         """ Parse command and run on particular node. """
         cwd = getcwd()
-        compute_command = self.command.replace('$ALL_CORES', str(psutil.cpu_count(logical=False)))
+        compute_command = self.command.replace('$ALL_CORES', str(psutil.cpu_count(logical=True)))
         print_notify('Executing {} on {}{}...'.format(compute_command, self.prefix, node))
         process = sp.Popen(['ssh', '{}{}'.format(self.prefix, node),
                             'cd', '{};'.format(cwd),

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -42,7 +42,7 @@ CASTEP_PRESENT = detect_program(EXECUTABLE)
 MPI_PRESENT = detect_program("mpirun")
 
 if CASTEP_PRESENT and MPI_PRESENT:
-    NCORES = max(psutil.cpu_count(logical=False) - 2, 1)
+    NCORES = max(psutil.cpu_count(logical=True) - 2, 1)
 else:
     NCORES = 1
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -25,7 +25,7 @@ CASTEP_PRESENT = detect_program(EXECUTABLE)
 MPI_PRESENT = detect_program("mpirun")
 
 if CASTEP_PRESENT and MPI_PRESENT:
-    NCORES = max(psutil.cpu_count(logical=False) - 2, 1)
+    NCORES = max(psutil.cpu_count(logical=True) - 2, 1)
 else:
     NCORES = 1
 


### PR DESCRIPTION
This PR closes #62 by reverting the change to `cpu_count` that took into account hyperthreading. Instead, we shall rely on error cancellation between dual-socket/non-hyperthreaded machines (the majority of x86 HPC) and revert using hyperthreading on machines where it is enabled (not ideal). Once the upstream PR is fixed in psutil, this change can be re-reverted...