### PR TITLE
v0.9.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+New in release (0.9.4) [08/06/2020]
+-----------------------------------
+- Fixed flag help strings for ``pxrd_calculator`` (#65)
+- Changed default PDF broadening for 3x speedup (#65)
+- Reverted ``cpu_count`` to use version that works correctly in most cases, by chance (#66).
+
 New in release (0.9.3) [07/06/2020]
 -----------------------------------
 

--- a/matador/__init__.py
+++ b/matador/__init__.py
@@ -11,6 +11,6 @@ theory compute engines.
 __all__ = ['__version__']
 __author__ = 'Matthew Evans'
 __maintainer__ = 'Matthew Evans'
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 
 script_epilog = f"Written and maintained by Matthew Evans (me388@cam.ac.uk) 2016-2020, version {__version__}."


### PR DESCRIPTION
- Fixed flag help strings for ``pxrd_calculator`` (#65)
- Changed default PDF broadening for 3x speedup (#65)
- Reverted ``cpu_count`` to use version that works correctly in most cases, by chance (#66).