### PR TITLE
v0.9.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,18 @@
 Changelog
 =========
 
+New in release (0.9.5) [25/06/2020]
+-----------------------------------
+- This release is mostly to trigger Zenodo archiving.
+- Updated README and tests for recent Python versions.
+
+
 New in release (0.9.4) [08/06/2020]
 -----------------------------------
 - Fixed flag help strings for ``pxrd_calculator`` (#65)
 - Changed default PDF broadening for 3x speedup (#65)
 - Reverted ``cpu_count`` to use version that works correctly in most cases, by chance (#66).
+
 
 New in release (0.9.3) [07/06/2020]
 -----------------------------------
@@ -13,6 +20,7 @@ New in release (0.9.3) [07/06/2020]
 - Fixes for the CIF reader: now works with awkward linebreaks and alternative symmetry operation specifications (#61).
 - Added several new flags to ``pxrd_calculator`` script (#60 and 61).
 - Usability fixes for ``spectral_plotting`` in the case of projected dispersion curves (#59).
+
 
 New in release (0.9.2) [01/06/2020]
 -----------------------------------
@@ -35,6 +43,7 @@ New in release (0.9.1) [20/05/2020]
 - Fixed issue where bands would be reordered multiple times in spectral plots (#40)
 - Tweaked spectral plot defaults (#40)
 - Replaced ``multiprocessing.cpu_count()`` calls with ``psutil.cpu_count(logical=False)`` to avoid double-counting hyperthreaded cores
+
 
 New in release (0.9) [15/05/2020]
 ---------------------------------

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 matador
 =======
 
-|PyPI Version| |GH Actions| |Coverage Status| |Documentation Status| |MIT License|
+|PyPI Version| |Zenodo| |GH Actions| |Coverage Status| |Documentation Status| |MIT License|
 
 matador is an aggregator, manipulator and runner of first-principles calculations, written with a bent towards battery electrode materials.
 The source can be found on `GitHub <https://github.com/ml-evs/matador>`_ and online documentation is hosted on `ReadTheDocs <https://docs.matador.science>`_.
@@ -65,3 +65,5 @@ If you think this list is outdated, incorrect or simply incomplete, then please 
   :target: https://codecov.io/gh/ml-evs/matador
 .. |Documentation Status| image:: https://readthedocs.org/projects/matador-db/badge/?version=stable
    :target: https://matador-db.readthedocs.io/en/stable/?badge=stable
+.. |Zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3908573.svg
+   :target: https://doi.org/10.5281/zenodo.3908573

--- a/matador/__init__.py
+++ b/matador/__init__.py
@@ -11,6 +11,6 @@ theory compute engines.
 __all__ = ['__version__']
 __author__ = 'Matthew Evans'
 __maintainer__ = 'Matthew Evans'
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 
 script_epilog = f"Written and maintained by Matthew Evans (me388@cam.ac.uk) 2016-2020, version {__version__}."


### PR DESCRIPTION
- This release is mostly to trigger Zenodo archiving.
- Updated README and tests for recent Python versions.