### PR TITLE
ENH: added support for CASTEP kpoint path `BREAK` directive

### DIFF
--- a/tests/data/cell_files/kpoint_path.cell
+++ b/tests/data/cell_files/kpoint_path.cell
@@ -16,6 +16,7 @@ C               0.333256        0.666746        0.002511
 %block spectral_kpoint_path
 0.0 0.0 0.0 !$\Gamma$
 0.0 0.0 0.5 ! Z
+BREAK
 0.0 0.5 0.0 #    $Y$
 0.5 0.0 0.0     %    X
 %endblock spectral_kpoint_path


### PR DESCRIPTION
Allows matador to read spectral paths that have the `BREAK` magic word in them. The keyword is ignored, but related functionality (e.g. dispersion script and the `ElectronicDispersion` class) will figure out the discontinuities themselves.