### PR TITLE
Fixes for spectral models, and added a spectral DOS step to magres workflow

### DIFF
--- a/matador/workflows/castep/magres.py
+++ b/matador/workflows/castep/magres.py
@@ -27,7 +27,7 @@ LOG = logging.getLogger('run3')
 __all__ = ("castep_full_magres")
 
 
-def castep_full_magres(computer, calc_doc, seed, final_elec_energy_tol=1e-12, **kwargs):
+def castep_full_magres(computer, calc_doc, seed, final_elec_energy_tol=1e-11, **kwargs):
     """ Perform a "full" magres calculation on a system, i.e.
     first perform a relaxation, then do a high quality SCF
     and compute NMR properties in the same step.
@@ -80,7 +80,7 @@ class CastepMagresWorkflow(Workflow):
 
         """
 
-        self.final_elec_energy_tol = self.workflow_params.get("elec_energy_tol", 1e-12)
+        self.final_elec_energy_tol = self.workflow_params.get("final_elec_energy_tol", 1e-11)
         # default todo
         todo = {'relax': True, 'scf': True, 'dos': True, 'pdos': True, 'broadening': True, 'magres': True}
         # definition of steps and names
@@ -139,7 +139,7 @@ class CastepMagresWorkflow(Workflow):
                               output_exts=exts[key].get('output'))
 
 
-def castep_magres_scf(computer, calc_doc, seed, elec_energy_tol=1e-12):
+def castep_magres_scf(computer, calc_doc, seed, elec_energy_tol=1e-11):
     """ Run a singleshot SCF calculation with a high elec_energy_tol.
 
     Parameters:
@@ -161,7 +161,7 @@ def castep_magres_scf(computer, calc_doc, seed, elec_energy_tol=1e-12):
     )
 
 
-def castep_magres(computer, calc_doc, seed, elec_energy_tol=1e-12):
+def castep_magres(computer, calc_doc, seed, elec_energy_tol=1e-11):
     """ Runs a NMR properties calculation on top of a completed
     SCF calculation.
 

--- a/matador/workflows/castep/spectral.py
+++ b/matador/workflows/castep/spectral.py
@@ -139,16 +139,6 @@ class CastepSpectralWorkflow(Workflow):
                               input_exts=exts[key].get('input'),
                               output_exts=exts[key].get('output'))
 
-        if self.computer.run3_settings.get('run3_settings') is not None:
-            settings = self.computer.kwargs.get('run3_settings')
-            # check that computer.exec was not overriden at cmd-line, then check settings file
-            if settings.get('castep_executable') is not None and self.computer.executable == 'castep':
-                self.castep_executable = settings.get('castep_executable', 'castep')
-                self.computer.executable = self.castep_executable
-            if settings.get('optados_executable') is not None:
-                self.optados_executable = settings.get('optados_executable', 'optados')
-                self.computer.optados_executable = self.optados_executable
-
         # if not using a user-requested path, use seekpath and spglib
         # to reduce to primitive and use consistent path
         if 'spectral_kpoints_list' not in self.calc_doc and 'spectral_kpoints_path' not in self.calc_doc:
@@ -169,8 +159,6 @@ class CastepSpectralWorkflow(Workflow):
 
         # always use continuation
         self.calc_doc['continuation'] = 'default'
-
-        LOG.info('Preprocessing completed: run3 spectral options {}'.format(todo))
 
 
 def castep_spectral_scf(computer, calc_doc, seed):

--- a/matador/workflows/workflows.py
+++ b/matador/workflows/workflows.py
@@ -60,7 +60,19 @@ class Workflow:
 
         LOG.info('Performing Workflow of type {} on {}'.format(self.label, self.seed))
 
+        if self.computer.run3_settings.get('run3_settings') is not None:
+            settings = self.computer.kwargs.get('run3_settings')
+            # check that computer.exec was not overriden at cmd-line, then check settings file
+            if settings.get('castep_executable') is not None and self.computer.executable == 'castep':
+                self.castep_executable = settings.get('castep_executable', 'castep')
+                self.computer.executable = self.castep_executable
+            if settings.get('optados_executable') is not None:
+                self.optados_executable = settings.get('optados_executable', 'optados')
+                self.computer.optados_executable = self.optados_executable
+
         self.preprocess()
+        LOG.info('Preprocessing completed, steps to perform: {}'.format([step.name for step in self.steps]))
+
         try:
             self.run_steps()
         except RuntimeError as exc:
@@ -79,8 +91,8 @@ class Workflow:
         responsible for adding WorkflowStep objects to the Workflow.
 
         """
-        raise NotImplementedError('Please implement a preprocess method.')
 
+    @abc.abstractmethod
     def postprocess(self):
         """ This OPTIONAL function is run upon successful completion of all steps
         of the workflow and can be overloaded by the subclass to perform


### PR DESCRIPTION
The main change in this PR is the addition of a DOS calculation on the high-quality SCF performed before an NMR calculation. With a bit of refactoring of the spectral workflow steps (i.e. make it so that the cell is not standardized, and the path is computed JIT) a bandstructure could be calculated too. This workflow is parameterised by the `final_elec_energy_tol` used for the magres, which defaults to `1e-11`. Relaxation steps will use the value in the param file.

This PR also has a few other side effects:
- [x] A workaround has been provided for the (now-fixed) OptaDOS bug https://github.com/optados-developers/optados/issues/24, by guessing the Fermi energy of a PDOS from the difference between the total DOS and PDOS grids for spin polarized systems, actually implemented in b9bf3b808fd19b75a483bc1ed9eaafdc6480cee3
- [x] Improvements to magres plotting, ability to set signal limits and use an infinite colour cycle