### PR TITLE
v0.9.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@
 Changelog
 =========
 
+New in release (0.9.9) [16/10/2020]
+-----------------------------------
+
+- Added support for CASTEP kpoint path ``BREAK`` directive (#107)
+- Improvements to magres plotting and magres workflow (#112)
+- Added ability to scrape electric field gradient values and compute quadrupolar quantities from NMR calculations (#115)
+- Added ability to run all several examples under Binder (#106, #130).
+- JOSS paper accepted! (#129)
+
+
 New in release (0.9.8) [10/08/2020]
 -----------------------------------
 - Improvements to PDIS functionality (#94).

--- a/README.rst
+++ b/README.rst
@@ -68,9 +68,12 @@ If you think this list is outdated, incorrect or simply incomplete, then please 
 Citing matador
 --------------
 
-If you use matador in your work, we kindly ask that you cite the source code archive on Zenodo:
+If you use matador in your work, we kindly ask that you cite
 
-    Matthew Evans, ml-evs/matador (2020), Zenodo. http://doi.org/10.5281/zenodo.3908574
+    Matthew Evans, Andrew Morris, *matador: a Python library for analysing, curating and performing high-throughput density-functional theory calculations* Journal of Open Source Software (2020)
+    `URL <https://joss.theoj.org/papers/4d0eea9bea4362dec4cb6d62ebccc913>`_
+
+Source code archives for all versions above 0.9 can be found at Zenodo `DOI 10.5281/zenodo.3908573 <https://doi.org/10.5281/zenodo.3908573>`_.
 
 
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/matador-db?label=PyPI&logo=pypi

--- a/matador/__init__.py
+++ b/matador/__init__.py
@@ -11,6 +11,6 @@ theory compute engines.
 __all__ = ['__version__']
 __author__ = 'Matthew Evans'
 __maintainer__ = 'Matthew Evans'
-__version__ = "0.9.8"
+__version__ = "0.9.9"
 
 script_epilog = f"Written and maintained by Matthew Evans (me388@cam.ac.uk) 2016-2020, version {__version__}."


### PR DESCRIPTION
- Added support for CASTEP kpoint path ``BREAK`` directive (#107)
- Improvements to magres plotting and magres workflow (#112)
- Added ability to scrape electric field gradient values and compute quadrupolar quantities from NMR calculations (#115)
- Added ability to run all several examples under Binder (#106, #130).
- JOSS paper accepted! (#129)