### PR TITLE
Bump psutil to 5.7.3 to use improved core counter

### DIFF
--- a/matador/compute/batch.py
+++ b/matador/compute/batch.py
@@ -125,7 +125,7 @@ class BatchRun:
             self.start_time = time.time()
 
         # assign number of cores
-        self.all_cores = psutil.cpu_count(logical=True)
+        self.all_cores = psutil.cpu_count(logical=False)
         if self.args.get('ncores') is None:
             if self.queue_mgr is None:
                 self.args['ncores'] = int(self.all_cores / self.nprocesses)

--- a/matador/fingerprints/fingerprint.py
+++ b/matador/fingerprints/fingerprint.py
@@ -131,7 +131,7 @@ class FingerprintFactory(abc.ABC):
     Note:
         The number of processes used to concurrency is set by the following
         hierarchy:
-        SLURM_NTASKS -> OMP_NUM_THREADS -> `psutil.cpu_count(logical=False)`.
+        ``$SLURM_NTASKS -> $OMP_NUM_THREADS -> psutil.cpu_count(logical=False)``.
 
     Attributes:
         nprocs (int): number of concurrent processes to be used.
@@ -142,7 +142,7 @@ class FingerprintFactory(abc.ABC):
 
     def __init__(self, cursor, required_inds=None, debug=False, **fprint_args):
         """ Compute PDFs over n processes, where n is set by either
-        SLURM_NTASKS, OMP_NUM_THREADS or physical core count.
+        ``$SLURM_NTASKS``, ``$OMP_NUM_THREADS`` or physical core count.
 
         Parameters:
             cursor (list of dict): list of matador structures

--- a/matador/fingerprints/fingerprint.py
+++ b/matador/fingerprints/fingerprint.py
@@ -131,7 +131,7 @@ class FingerprintFactory(abc.ABC):
     Note:
         The number of processes used to concurrency is set by the following
         hierarchy:
-        SLURM_NTASKS -> OMP_NUM_THREADS -> `psutil.cpu_count(logical=True)`.
+        SLURM_NTASKS -> OMP_NUM_THREADS -> `psutil.cpu_count(logical=False)`.
 
     Attributes:
         nprocs (int): number of concurrent processes to be used.
@@ -187,7 +187,7 @@ class FingerprintFactory(abc.ABC):
             self.nprocs = int(os.environ.get('OMP_NUM_THREADS'))
             env = '$OMP_NUM_THREADS'
         else:
-            self.nprocs = psutil.cpu_count(logical=True)
+            self.nprocs = psutil.cpu_count(logical=False)
             env = 'core count'
         print_notify('Running {} jobs on at most {} processes, set by {}.'
                      .format(len(required_inds), self.nprocs, env))

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.14
 scipy>=1.0
-psutil>=5.0
+psutil>=5.7.3
 pyyaml>=5.3
 pymongo>=3.7
 numba>=0.4

--- a/scripts/oddjob
+++ b/scripts/oddjob
@@ -53,7 +53,7 @@ class Hive:
         """ Parse command and run on particular node. """
         cwd = getcwd()
         compute_command = self.command.replace(
-            "$ALL_CORES", str(psutil.cpu_count(logical=True))
+            "$ALL_CORES", str(psutil.cpu_count(logical=False))
         )
         print_notify(
             "Executing {} on {}{}...".format(compute_command, self.prefix, node)
@@ -106,7 +106,11 @@ if __name__ == "__main__":
     PARSER.add_argument("-d", "--debug", action="store_true", help="debug output")
     ARGS = PARSER.parse_args()
     RUNNER = Hive(
-        command=ARGS.command, nodes=ARGS.nodes, debug=ARGS.debug, prefix=ARGS.prefix, sleep=ARGS.sleep
+        command=ARGS.command,
+        nodes=ARGS.nodes,
+        debug=ARGS.debug,
+        prefix=ARGS.prefix,
+        sleep=ARGS.sleep,
     )
     try:
         RUNNER.spawn()

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -42,7 +42,7 @@ CASTEP_PRESENT = detect_program(EXECUTABLE)
 MPI_PRESENT = detect_program("mpirun")
 
 if CASTEP_PRESENT and MPI_PRESENT:
-    NCORES = max(psutil.cpu_count(logical=True) - 2, 1)
+    NCORES = max(psutil.cpu_count(logical=False) - 2, 1)
 else:
     NCORES = 1
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -25,7 +25,7 @@ CASTEP_PRESENT = detect_program(EXECUTABLE)
 MPI_PRESENT = detect_program("mpirun")
 
 if CASTEP_PRESENT and MPI_PRESENT:
-    NCORES = max(psutil.cpu_count(logical=True) - 2, 1)
+    NCORES = max(psutil.cpu_count(logical=False) - 2, 1)
 else:
     NCORES = 1
 


### PR DESCRIPTION
Thus ends the saga of #41, #62, #66... now core counting should be correct for single and multisocket machines irrespective of hyperthreading.

Closes #62. 