### PR TITLE
Remove codecov token from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,5 @@ jobs:
       if: matrix.python-version == 3.8 && github.repository == 'ml-evs/matador'
       uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
The token has not been needed for a while anyway. Prompted by https://about.codecov.io/security-update/