### PR TITLE
v0.9.11 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,12 +3,20 @@
 Changelog
 =========
 
+New in release (0.9.11) [03/06/2021]
+------------------------------------
+
+- Minor change: allow specification of arbitrary strings for CASTEP pseudopotential libraries (#156).
+- Bug fix: ``standardize_cell`` script failing to use default symmetry tolerance value (#157).
+- Bug fix: scraping of .cif files with single atoms and no symmetries (#173)
+- Bug fix: scraping of Hubbard U values from .castep files, and associated bugs when performing relaxations with Hubbard U (#180)
+- Dependency updates and Python 3.6 deprecation warning (#158, #181)
+
 New in release (0.9.10) [23/02/2021]
 ------------------------------------
 
 - Windows compatibility changes (#149)
 - Dependency updates (#146, #148, #149)
-
 
 New in release (0.9.9) [16/10/2020]
 -----------------------------------

--- a/matador/__init__.py
+++ b/matador/__init__.py
@@ -13,9 +13,9 @@ import sys
 __all__ = ['__version__']
 __author__ = 'Matthew Evans'
 __maintainer__ = 'Matthew Evans'
-__version__ = "0.9.10"
+__version__ = "0.9.11"
 
-script_epilog = f"Written and maintained by Matthew Evans (me388@cam.ac.uk) 2016-2020, version {__version__}."
+script_epilog = f"Written and maintained by Matthew Evans (me388@cam.ac.uk) 2016-2021, version {__version__}."
 
 if sys.version_info.minor == 6:
     # Python 3.6


### PR DESCRIPTION
- Minor change: allow specification of arbitrary strings for CASTEP pseudopotential libraries (#156).
- Bug fix: standardize_cell script failing to use default symmetry tolerance value (#157).
- Bug fix: scraping of .cif files with single atoms and no symmetries (#173)
- Bug fix: scraping of Hubbard U values from .castep files, and associated bugs when performing relaxations with Hubbard U (#180)
 - Dependency updates and Python 3.6 deprecation warning (#158, #181)
