### PR TITLE
Fix failure to scrape magres files with more than 100 atoms

### DIFF
--- a/matador/scrapers/magres_scrapers.py
+++ b/matador/scrapers/magres_scrapers.py
@@ -36,7 +36,7 @@ def magres2dict(fname, **kwargs):
         magres['user'] = getpwuid(stat(fname).st_uid).pw_name
     except Exception:
         magres['user'] = 'xxx'
-        
+
     magres['magres_units'] = dict()
     for line_no, line in enumerate(flines):
         line = line.lower().strip()
@@ -62,12 +62,12 @@ def magres2dict(fname, **kwargs):
                     magres['positions_abs'].append([float(elem) for elem in atom[-3:]])
                 i += 1
             break
-            
+
     if "atom_types" in magres:
         magres['num_atoms'] = len(magres['atom_types'])
         magres['positions_frac'] = cart2frac(magres['lattice_cart'], magres['positions_abs'])
         magres['stoichiometry'] = get_stoich(magres['atom_types'])
-        
+
     for line_no, line in enumerate(flines):
         line = line.lower().strip()
         if line in ['<magres>', '[magres]']:
@@ -120,7 +120,7 @@ def magres2dict(fname, **kwargs):
                     magres["quadrupolar_asymmetries"].append(eta)
 
                 i += 1
-                
+
     for line_no, line in enumerate(flines):
         line = line.lower().strip()
         if line in ['<calculation>', '[calculation]']:

--- a/matador/scrapers/magres_scrapers.py
+++ b/matador/scrapers/magres_scrapers.py
@@ -36,7 +36,6 @@ def magres2dict(fname, **kwargs):
         magres['user'] = getpwuid(stat(fname).st_uid).pw_name
     except Exception:
         magres['user'] = 'xxx'
-
     magres['magres_units'] = dict()
     for line_no, line in enumerate(flines):
         line = line.lower().strip()
@@ -62,12 +61,11 @@ def magres2dict(fname, **kwargs):
                     magres['positions_abs'].append([float(elem) for elem in atom[-3:]])
                 i += 1
             break
-
     if "atom_types" in magres:
         magres['num_atoms'] = len(magres['atom_types'])
         magres['positions_frac'] = cart2frac(magres['lattice_cart'], magres['positions_abs'])
         magres['stoichiometry'] = get_stoich(magres['atom_types'])
-
+    
     for line_no, line in enumerate(flines):
         line = line.lower().strip()
         if line in ['<magres>', '[magres]']:
@@ -85,7 +83,7 @@ def magres2dict(fname, **kwargs):
                     magres["susceptibility_tensor"] = np.array([float(val) for val in split_line[1:]]).reshape(3, 3)
 
                 elif 'ms' in split_line:
-                    ms = np.array([float(val) for val in split_line[3:]]).reshape(3, 3)
+                    ms = np.array([float(val) for val in split_line[-9:]]).reshape(3, 3)
                     s_iso = np.trace(ms) / 3
 
                     # find eigenvalues of symmetric part of shielding and order them to calc anisotropy eta
@@ -120,7 +118,6 @@ def magres2dict(fname, **kwargs):
                     magres["quadrupolar_asymmetries"].append(eta)
 
                 i += 1
-
     for line_no, line in enumerate(flines):
         line = line.lower().strip()
         if line in ['<calculation>', '[calculation]']:

--- a/matador/scrapers/magres_scrapers.py
+++ b/matador/scrapers/magres_scrapers.py
@@ -36,6 +36,7 @@ def magres2dict(fname, **kwargs):
         magres['user'] = getpwuid(stat(fname).st_uid).pw_name
     except Exception:
         magres['user'] = 'xxx'
+        
     magres['magres_units'] = dict()
     for line_no, line in enumerate(flines):
         line = line.lower().strip()
@@ -61,11 +62,12 @@ def magres2dict(fname, **kwargs):
                     magres['positions_abs'].append([float(elem) for elem in atom[-3:]])
                 i += 1
             break
+            
     if "atom_types" in magres:
         magres['num_atoms'] = len(magres['atom_types'])
         magres['positions_frac'] = cart2frac(magres['lattice_cart'], magres['positions_abs'])
         magres['stoichiometry'] = get_stoich(magres['atom_types'])
-    
+        
     for line_no, line in enumerate(flines):
         line = line.lower().strip()
         if line in ['<magres>', '[magres]']:
@@ -118,6 +120,7 @@ def magres2dict(fname, **kwargs):
                     magres["quadrupolar_asymmetries"].append(eta)
 
                 i += 1
+                
     for line_no, line in enumerate(flines):
         line = line.lower().strip()
         if line in ['<calculation>', '[calculation]']:


### PR DESCRIPTION
CASTEP magres files store magnetic shielding information in the form:
```
ms O 99         -2.0523362330721022E+02          3.6848981558575366E+02         -2.2771013606692599E-02          3.5814867568808620E+02         -2.9946873927125921E+02         -1.0428524506521353E+00          7.9458932961222715E-03         -2.2003847124460636E-03         -5.5724953570109824E+02
```
Where O is the element and 99 is a numerical index. When that index reaches 100, the space after the O is lost, resulting in a line like:
```
ms O100         -2.0179072731970462E+02          3.6630064905427832E+02          1.2616916920493680E-02          3.5658185566204065E+02         -3.0353628246235576E+02         -1.0440187939142316E+00         -1.5038528456938940E-02          3.7592007872482180E-02         -5.5287819200589945E+02
```

Applying Python's split function to each line therefore yields:
```
['ms', 'O', '99', '-2.0523362330721022E+02', '3.6848981558575366E+02', '-2.2771013606692599E-02', '3.5814867568808620E+02', '-2.9946873927125921E+02', '-1.0428524506521353E+00', '7.9458932961222715E-03', '-2.2003847124460636E-03', '-5.5724953570109824E+02']
101
['ms', 'O100', '-2.0179072731970462E+02', '3.6630064905427832E+02', '1.2616916920493680E-02', '3.5658185566204065E+02', '-3.0353628246235576E+02', '-1.0440187939142316E+00', '-1.5038528456938940E-02', '3.7592007872482180E-02', '-5.5287819200589945E+02']
```

The second list is one element shorter, which resulted in one element of the magnetic shielding being ignored for indices above 99.
`magres_scraper` now takes the last 9 elements, instead of all elements after the first 3.