### PR TITLE
Added function to reference chemical shifts from shieldings

### DIFF
--- a/matador/plotting/magres_plotting.py
+++ b/matador/plotting/magres_plotting.py
@@ -31,7 +31,7 @@ def plot_magres(
     signal_labels: Optional[Union[str, List[str]]] = None,
     signal_limits: Tuple[float] = None,
     line_kwargs: Optional[Union[Dict, List[Dict]]] = None,
-    flipxax: bool = False,
+    invert_xaxis: bool = True,
 ):
     """ Plot magnetic resonance.
 

--- a/matador/plotting/magres_plotting.py
+++ b/matador/plotting/magres_plotting.py
@@ -191,7 +191,7 @@ def plot_magres(
         ax.set_yticks(np.linspace(0, 1, 5, endpoint=True))
 
     ax.set_ylim(-0.1, 1.1 * len(magres))
-    if flipxax:
+    if invert_xaxis:
         ax.invert_xaxis()
 
     if savefig:

--- a/matador/plotting/magres_plotting.py
+++ b/matador/plotting/magres_plotting.py
@@ -25,12 +25,15 @@ def plot_magres(
     broadening_width: float = 1,
     text_offset: float = 0.1,
     ax=None,
+    cor_constant: float = 0,
+    cor_gradient: float = 1,
     figsize: Tuple[float] = None,
     show: bool = False,
     savefig: Optional[str] = None,
     signal_labels: Optional[Union[str, List[str]]] = None,
     signal_limits: Tuple[float] = None,
     line_kwargs: Optional[Union[Dict, List[Dict]]] = None,
+    flipxax: bool = False,
 ):
     """ Plot voltage curve calculated for phase diagram.
 
@@ -45,6 +48,8 @@ def plot_magres(
         show (bool): whether to show plot in an X window.
         figsize (Tuple[float]): overrides the default size for the matplotlib figure.
         broadening_width (float): the Lorentzian width to apply to the shifts.
+        cor_constant (float): a linear correction to apply to magres shifts.
+        cor_gradient (float): a gradient correction to apply to magres shifts.
         xlabel (str): a custom label for the x-axis.
         savefig (str): filename to use to save the plot.
         signal_labels (list): optional list of labels for the curves in
@@ -100,7 +105,8 @@ def plot_magres(
 
         relevant_sites = [atom for atom in _doc if atom.species == species]
         if relevant_sites:
-            shielding = [atom[magres_key] for atom in relevant_sites]
+            # cor_gradient and cor_constant are 1 and 0 by default and are effectively ignored
+            shielding = [(atom[magres_key]*cor_gradient + cor_constant) for atom in relevant_sites]
             if signal_limits is None:
                 min_shielding = min(np.min(shielding), min_shielding)
                 max_shielding = max(np.max(shielding), max_shielding)
@@ -144,7 +150,7 @@ def plot_magres(
             signal = np.zeros_like(s_space)
 
         else:
-            shifts = [site[magres_key] for site in relevant_sites]
+            shifts = [(site[magres_key]*cor_gradient + cor_constant) for site in relevant_sites]
 
             hist, bins = np.histogram(shifts, bins=s_space)
 
@@ -190,6 +196,8 @@ def plot_magres(
         ax.set_yticks(np.linspace(0, 1, 5, endpoint=True))
 
     ax.set_ylim(-0.1, 1.1 * len(magres))
+    if flipxax:
+        ax.invert_xaxis()
 
     if savefig:
         plt.savefig(savefig)

--- a/matador/plotting/magres_plotting.py
+++ b/matador/plotting/magres_plotting.py
@@ -25,8 +25,6 @@ def plot_magres(
     broadening_width: float = 1,
     text_offset: float = 0.1,
     ax=None,
-    cor_constant: float = 0,
-    cor_gradient: float = 1,
     figsize: Tuple[float] = None,
     show: bool = False,
     savefig: Optional[str] = None,
@@ -35,7 +33,7 @@ def plot_magres(
     line_kwargs: Optional[Union[Dict, List[Dict]]] = None,
     flipxax: bool = False,
 ):
-    """ Plot voltage curve calculated for phase diagram.
+    """ Plot magnetic resonance.
 
     Parameters:
         magres (Union[Crystal, List[Crystal]]): list of :class:`Crystal` containing
@@ -48,8 +46,6 @@ def plot_magres(
         show (bool): whether to show plot in an X window.
         figsize (Tuple[float]): overrides the default size for the matplotlib figure.
         broadening_width (float): the Lorentzian width to apply to the shifts.
-        cor_constant (float): a linear correction to apply to magres shifts.
-        cor_gradient (float): a gradient correction to apply to magres shifts.
         xlabel (str): a custom label for the x-axis.
         savefig (str): filename to use to save the plot.
         signal_labels (list): optional list of labels for the curves in
@@ -105,8 +101,7 @@ def plot_magres(
 
         relevant_sites = [atom for atom in _doc if atom.species == species]
         if relevant_sites:
-            # cor_gradient and cor_constant are 1 and 0 by default and are effectively ignored
-            shielding = [(atom[magres_key]*cor_gradient + cor_constant) for atom in relevant_sites]
+            shielding = [atom[magres_key] for atom in relevant_sites]
             if signal_limits is None:
                 min_shielding = min(np.min(shielding), min_shielding)
                 max_shielding = max(np.max(shielding), max_shielding)
@@ -144,13 +139,15 @@ def plot_magres(
         if line_kwargs is not None:
             _line_kwargs.update(line_kwargs[ind])
 
-        relevant_sites = [site for site in doc if site.species == species]
+        _doc = _magres[ind]
+
+        relevant_sites = [site for site in _doc if site.species == species]
         if not relevant_sites:
             print(f"No sites of {species} found in {doc.root_source}, signal will be empty.")
             signal = np.zeros_like(s_space)
 
         else:
-            shifts = [(site[magres_key]*cor_gradient + cor_constant) for site in relevant_sites]
+            shifts = [site[magres_key] for site in relevant_sites]
 
             hist, bins = np.histogram(shifts, bins=s_space)
 

--- a/matador/plotting/magres_plotting.py
+++ b/matador/plotting/magres_plotting.py
@@ -125,7 +125,7 @@ def plot_magres(
             .format(len(line_kwargs), len(magres))
         )
 
-    for ind, doc in enumerate(magres):
+    for ind, doc in enumerate(_magres):
         if signal_labels is None:
             stoich_label = doc.formula_tex
         else:
@@ -139,9 +139,7 @@ def plot_magres(
         if line_kwargs is not None:
             _line_kwargs.update(line_kwargs[ind])
 
-        _doc = _magres[ind]
-
-        relevant_sites = [site for site in _doc if site.species == species]
+        relevant_sites = [site for site in doc if site.species == species]
         if not relevant_sites:
             print(f"No sites of {species} found in {doc.root_source}, signal will be empty.")
             signal = np.zeros_like(s_space)

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -655,13 +655,13 @@ def magres_reference_shifts(
     """Set chemical shifts inside a matador document from shieldings and a given reference.
 
     Parameters:
-        magres (Dict[str, Any]): A matador document containing the structure and magres shielding data.
-        reference (Dict[str, Tuple[float, float]]): dictionary of conversion values in the form {element: [gradient, constant]}.
+        magres (list): A matador document containing the structure and magres shielding data.
+        eference (Dict[str, Tuple[float, float]]): dictionary of conversion values in the form {element: [gradient, constant]}.
 
     Keyword arguments:
         shielding_key (str): the data key for which the shielding is stored under.
         shift_key (str): the data key for which the shift will be stored under.
-        
+
    Returns:
         The input dictionary with the `chemical_shift_isos` key set to the referenced shifts.
     """
@@ -669,14 +669,10 @@ def magres_reference_shifts(
     shielding_key_plural = shielding_key + "s"
     shift_key_plural = shift_key + "s"
 
-    chemical_shifts = []
+    chemical_shifts = magres.get(shift_key_plural, len(magres["atom_types"]) * [None])
     for ind, species in enumerate(magres["atom_types"]):
-        if species in relevant_species:
+        if species in reference:
             chemical_shift = (magres[shielding_key_plural][ind] * reference[species][0]) + reference[species][1]
-            chemical_shifts.append(chemical_shift)
-        else:
-            chemical_shifts.append(None)
+            chemical_shifts[ind] = chemical_shift
 
     magres[shift_key_plural] = chemical_shifts
-
-    return magres

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -655,7 +655,7 @@ def magres_reference_shifts(
     """ Convert chemical shielding to chemical shift.
 
     Parameters:
-        magres (list): list of containing magres data.
+        magres (Dict[str, Any]): A matador document containing the structure and magres shielding data.
         reference (str): dictionary of conversion values in the form {element: [gradient, constant]}.
 
     Keyword arguments:

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -647,7 +647,7 @@ def get_formula_from_stoich(stoich, elements=None, tex=False, sort=True, latex_s
     return form
 
 def magres_reference_shifts(
-    magres: list,
+    magres: Dict[str, Any],
     reference: dict,
     shielding_key: str = "chemical_shielding_iso",
     shift_key: str = "chemical_shift_iso",

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -653,8 +653,8 @@ def magres_reference_shifts(
     """Set chemical shifts inside a matador document from shieldings and a given reference.
 
     Parameters:
-        magres (list): A matador document containing the structure and magres shielding data.
-        reference (Dict[str, Tuple[float, float]]): dictionary of conversion values in the form {element: [gradient, constant]}.
+        magres: A matador document containing the structure and magres shielding data.
+        reference: Reference values in the form `{element: [gradient, constant]}`.
 
    Returns:
         The input dictionary with the `chemical_shift_isos` key set to the referenced shifts.

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -661,6 +661,9 @@ def magres_reference_shifts(
     Keyword arguments:
         shielding_key (str): the data key for which the shielding is stored under.
         shift_key (str): the data key for which the shift will be stored under.
+        
+   Returns:
+        The input dictionary with the `chemical_shift_isos` key set to the referenced shifts.
     """
 
     relevant_species = list(reference.keys())

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -652,7 +652,7 @@ def magres_reference_shifts(
     shielding_key: str = "chemical_shielding_iso",
     shift_key: str = "chemical_shift_iso",
 ):
-    """ Convert chemical shielding to chemical shift.
+    """Set chemical shifts inside a matador document from shieldings and a given reference.
 
     Parameters:
         magres (Dict[str, Any]): A matador document containing the structure and magres shielding data.

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -664,8 +664,8 @@ def magres_reference_shifts(
     """
 
     relevant_species = list(reference.keys())
-    shielding_key_plural = ''.join([shielding_key, 's'])
-    shift_key_plural = ''.join([shift_key, 's'])
+    shielding_key_plural = shielding_key + "s"
+    shift_key_plural = shift_key + "s"
 
     chemical_shifts = []
     for ind, species in enumerate(magres["atom_types"]):

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -9,9 +9,11 @@ constants, with a focus on battery materials.
 
 import copy
 import warnings
+from typing import List, Union
 
 import numpy as np
 from matador.data.constants import * # noqa
+
 
 EPS = 1e-8
 
@@ -643,3 +645,36 @@ def get_formula_from_stoich(stoich, elements=None, tex=False, sort=True, latex_s
                 else:
                     form += elem[0] + str(int(elem[1]))
     return form
+
+def magres_reference_shifts(
+    magres: list,
+    reference: dict,
+    shielding_key: str = "chemical_shielding_iso",
+    shift_key: str = "chemical_shift_iso",
+):
+    """ Convert chemical shielding to chemical shift.
+
+    Parameters:
+        magres (list): list of containing magres data.
+        reference (str): dictionary of conversion values in the form {element: [gradient, constant]}.
+
+    Keyword arguments:
+        shielding_key (str): the data key for which the shielding is stored under.
+        shift_key (str): the data key for which the shift will be stored under.
+    """
+
+    relevant_species = list(reference.keys())
+    shielding_key_plural = ''.join([shielding_key, 's'])
+    shift_key_plural = ''.join([shift_key, 's'])
+
+    chemical_shifts = []
+    for ind, species in enumerate(magres["atom_types"]):
+        if species in relevant_species:
+            chemical_shift = (magres[shielding_key_plural][ind] * reference[species][0]) + reference[species][1]
+            chemical_shifts.append(chemical_shift)
+        else:
+            chemical_shifts.append(None)
+
+    magres[shift_key_plural] = chemical_shifts
+
+    return magres

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -646,6 +646,7 @@ def get_formula_from_stoich(stoich, elements=None, tex=False, sort=True, latex_s
                     form += elem[0] + str(int(elem[1]))
     return form
 
+
 def magres_reference_shifts(
     magres: Dict[str, Any],
     reference: Dict[str, Tuple[float, float]],

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -656,7 +656,7 @@ def magres_reference_shifts(
 
     Parameters:
         magres (Dict[str, Any]): A matador document containing the structure and magres shielding data.
-        reference (str): dictionary of conversion values in the form {element: [gradient, constant]}.
+        reference (Dict[str, Tuple[float, float]]): dictionary of conversion values in the form {element: [gradient, constant]}.
 
     Keyword arguments:
         shielding_key (str): the data key for which the shielding is stored under.

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -666,7 +666,6 @@ def magres_reference_shifts(
         The input dictionary with the `chemical_shift_isos` key set to the referenced shifts.
     """
 
-    relevant_species = list(reference.keys())
     shielding_key_plural = shielding_key + "s"
     shift_key_plural = shift_key + "s"
 

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -9,7 +9,7 @@ constants, with a focus on battery materials.
 
 import copy
 import warnings
-from typing import Dict, Union, Tuple, Any
+from typing import Dict, Tuple, Any
 
 import numpy as np
 from matador.data.constants import * # noqa

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -9,7 +9,7 @@ constants, with a focus on battery materials.
 
 import copy
 import warnings
-from typing import Optional, Dict, Union, Tuple, Any
+from typing import Dict, Union, Tuple, Any
 
 import numpy as np
 from matador.data.constants import * # noqa

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -648,7 +648,7 @@ def get_formula_from_stoich(stoich, elements=None, tex=False, sort=True, latex_s
 
 def magres_reference_shifts(
     magres: Dict[str, Any],
-    reference: dict,
+    reference: Dict[str, Tuple[float, float]],
 ):
     """Set chemical shifts inside a matador document from shieldings and a given reference.
 

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -9,7 +9,7 @@ constants, with a focus on battery materials.
 
 import copy
 import warnings
-from typing import List, Optional, Dict, Union, Tuple, Any
+from typing import Optional, Dict, Union, Tuple, Any
 
 import numpy as np
 from matador.data.constants import * # noqa

--- a/matador/utils/chem_utils.py
+++ b/matador/utils/chem_utils.py
@@ -9,7 +9,7 @@ constants, with a focus on battery materials.
 
 import copy
 import warnings
-from typing import List, Union
+from typing import List, Optional, Dict, Union, Tuple, Any
 
 import numpy as np
 from matador.data.constants import * # noqa
@@ -649,30 +649,21 @@ def get_formula_from_stoich(stoich, elements=None, tex=False, sort=True, latex_s
 def magres_reference_shifts(
     magres: Dict[str, Any],
     reference: dict,
-    shielding_key: str = "chemical_shielding_iso",
-    shift_key: str = "chemical_shift_iso",
 ):
     """Set chemical shifts inside a matador document from shieldings and a given reference.
 
     Parameters:
         magres (list): A matador document containing the structure and magres shielding data.
-        eference (Dict[str, Tuple[float, float]]): dictionary of conversion values in the form {element: [gradient, constant]}.
-
-    Keyword arguments:
-        shielding_key (str): the data key for which the shielding is stored under.
-        shift_key (str): the data key for which the shift will be stored under.
+        reference (Dict[str, Tuple[float, float]]): dictionary of conversion values in the form {element: [gradient, constant]}.
 
    Returns:
         The input dictionary with the `chemical_shift_isos` key set to the referenced shifts.
     """
 
-    shielding_key_plural = shielding_key + "s"
-    shift_key_plural = shift_key + "s"
-
-    chemical_shifts = magres.get(shift_key_plural, len(magres["atom_types"]) * [None])
+    chemical_shifts = magres.get('chemical_shift_isos', len(magres["atom_types"]) * [None])
     for ind, species in enumerate(magres["atom_types"]):
         if species in reference:
-            chemical_shift = (magres[shielding_key_plural][ind] * reference[species][0]) + reference[species][1]
+            chemical_shift = (magres['chemical_shielding_isos'][ind] * reference[species][0]) + reference[species][1]
             chemical_shifts[ind] = chemical_shift
 
-    magres[shift_key_plural] = chemical_shifts
+    magres['chemical_shift_isos'] = chemical_shifts

--- a/tests/test_chem_utils.py
+++ b/tests/test_chem_utils.py
@@ -480,13 +480,16 @@ class ChemUtilsTest(unittest.TestCase):
         magres = {"chemical_shielding_isos": [100, 75, -50, -25, 0, 100, 75, -50, -25, 0],
                   "atom_types": ["H", "H", "H", "H", "H", "Li", "Li", "Li", "Li", "Li"]}
 
-        magres_with_shifts = {  "chemical_shielding_isos": [100, 75, -50, -25, 0, 100, 75, -50, -25, 0],
-                                "atom_types": ["H", "H", "H", "H", "H", "Li", "Li", "Li", "Li", "Li"],
-                                "chemical_shift_isos": [-49.0, -36.5, 26.0, 13.5, 1.0, None, None, None, None, None]}
+        magres_with_shifts = {"chemical_shielding_isos": [100, 75, -50, -25, 0, 100, 75, -50, -25, 0],
+                              "atom_types": ["H", "H", "H", "H", "H", "Li", "Li", "Li", "Li", "Li"],
+                              "chemical_shift_isos": [-49.0, -36.5, 26.0, 13.5, 1.0, None, None, None, None, None]}
 
         magres_reference_shifts(magres=magres, reference={'H': [-0.5, 1]})
 
         self.assertEqual(magres, magres_with_shifts)
 
+        
 if __name__ == "__main__":
     unittest.main()
+
+    

--- a/tests/test_chem_utils.py
+++ b/tests/test_chem_utils.py
@@ -474,6 +474,19 @@ class ChemUtilsTest(unittest.TestCase):
         src = "not even a list"
         self.assertEqual(src, get_root_source(source))
 
+    def test_magres_reference_shifts(self):
+        from matador.utils.chem_utils import magres_reference_shifts
+
+        magres = {"chemical_shielding_isos": [100, 75, -50, -25, 0, 100, 75, -50, -25, 0],
+                  "atom_types": ["H", "H", "H", "H", "H", "Li", "Li", "Li", "Li", "Li"]}
+
+        magres_with_shifts = {  "chemical_shielding_isos": [100, 75, -50, -25, 0, 100, 75, -50, -25, 0],
+                                "atom_types": ["H", "H", "H", "H", "H", "Li", "Li", "Li", "Li", "Li"],
+                                "chemical_shift_isos": [-49.0, -36.5, 26.0, 13.5, 1.0, None, None, None, None, None]}
+
+        magres_reference_shifts(magres=magres, reference={'H': [-0.5, 1]})
+
+        self.assertEqual(magres, magres_with_shifts)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_chem_utils.py
+++ b/tests/test_chem_utils.py
@@ -488,8 +488,8 @@ class ChemUtilsTest(unittest.TestCase):
 
         self.assertEqual(magres, magres_with_shifts)
 
-        
+
 if __name__ == "__main__":
     unittest.main()
 
-    
+

--- a/tests/test_chem_utils.py
+++ b/tests/test_chem_utils.py
@@ -492,4 +492,3 @@ class ChemUtilsTest(unittest.TestCase):
 if __name__ == "__main__":
     unittest.main()
 
-

--- a/tests/test_chem_utils.py
+++ b/tests/test_chem_utils.py
@@ -491,4 +491,3 @@ class ChemUtilsTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
Updated magres_plotting with support for empirical corrections:
        cor_constant (correction constant) will apply a linear correction to the magres shift
	cor_gradient (correction gradient) will apply a gradient correction to the magres shift

Updated magres_plotting to support NMR x-axis conventions:
	specifying flipxaxis=true will invert the x-axis

Thank you to Angela for her contributions.