### PR TITLE
Support `continuation` and `magres_restart` in magres workflows

### DIFF
--- a/matador/compute/compute.py
+++ b/matador/compute/compute.py
@@ -386,6 +386,7 @@ class ComputeTask:
         if self.exec_test:
             self.test_exec()
 
+
         # pre-processing
         if self.kpts_1D:
             LOG.debug("1D kpoint grid requested.")
@@ -2049,7 +2050,22 @@ class ComputeTask:
         # if a checkfile exists, copy it to the new dir
         # so that it can be restarted from
         if os.path.isfile(seed + ".check"):
+            LOG.info("Copying .check into compute_dir")
             shutil.copy2(seed + ".check", compute_dir)
+
+        # if a magres .mag checkfile exists, copy it to the new dir
+        # so that it can be restarted from for a magres task
+        mag_files = glob.glob(seed + "*.mag") 
+        if mag_files:
+            LOG.info("Copying .mag files into compute_dir")
+            for _file in mag_files:
+                try:
+                    shutil.copy2(_file, compute_dir)
+                    os.remove(_file)
+                except Exception as exc:
+                    LOG.warning(
+                        "Error moving .mag file to compute: {error}".format(error=exc)
+                    )
 
     def scf(self, *args, **kwargs):
         """Alias for backwards-compatibility."""

--- a/matador/compute/compute.py
+++ b/matador/compute/compute.py
@@ -2055,7 +2055,7 @@ class ComputeTask:
 
         # if a magres .mag checkfile exists, copy it to the new dir
         # so that it can be restarted from for a magres task
-        mag_files = glob.glob(seed + "*.mag") 
+        mag_files = glob.glob(seed + ".*.mag") 
         if mag_files:
             LOG.info("Copying .mag files into compute_dir")
             for _file in mag_files:

--- a/matador/compute/compute.py
+++ b/matador/compute/compute.py
@@ -2054,7 +2054,7 @@ class ComputeTask:
 
         # if a magres .mag checkfile exists, copy it to the new dir
         # so that it can be restarted from for a magres task
-        mag_files = glob.glob(seed + ".*.mag") 
+        mag_files = glob.glob(seed + ".*.mag")
         if mag_files:
             LOG.info("Copying .mag files into compute_dir")
             for _file in mag_files:

--- a/matador/compute/compute.py
+++ b/matador/compute/compute.py
@@ -2056,7 +2056,7 @@ class ComputeTask:
         # so that it can be restarted from for a magres task
         mag_files = [
             f"{seed}.{num:04}.mag" for num in range(1, self.ncores * self.nnodes)
-        ]  
+        ]
         if os.path.isfile("%s.0001.mag" % (seed)):
             LOG.info("Copying .mag files into compute_dir")
             for _file in mag_files:

--- a/matador/compute/compute.py
+++ b/matador/compute/compute.py
@@ -2054,8 +2054,10 @@ class ComputeTask:
 
         # if a magres .mag checkfile exists, copy it to the new dir
         # so that it can be restarted from for a magres task
-        mag_files = glob.glob(seed + ".*.mag")
-        if mag_files:
+        mag_files = [
+            f"{seed}.{num:04}.mag" for num in range(1, self.ncores * self.nnodes)
+        ]  
+        if os.path.isfile("%s.0001.mag" % (seed)):
             LOG.info("Copying .mag files into compute_dir")
             for _file in mag_files:
                 try:

--- a/matador/compute/compute.py
+++ b/matador/compute/compute.py
@@ -386,7 +386,6 @@ class ComputeTask:
         if self.exec_test:
             self.test_exec()
 
-
         # pre-processing
         if self.kpts_1D:
             LOG.debug("1D kpoint grid requested.")

--- a/matador/scrapers/castep_scrapers.py
+++ b/matador/scrapers/castep_scrapers.py
@@ -694,7 +694,7 @@ def param2dict(fname, db=True, **kwargs):
                         while "%endblock devel_code" not in flines[line_no + i].lower():
                             if i + line_no >= len(flines):
                                 raise RuntimeError("Found unclosed %block devel_code.")
-                            if 'magres' in flines[line_no + i]:
+                            if "magres" in flines[line_no + i]:
                                 line = flines[line_no + i].upper()
                             else:
                                 line = flines[line_no + i].lower()

--- a/matador/scrapers/castep_scrapers.py
+++ b/matador/scrapers/castep_scrapers.py
@@ -694,7 +694,7 @@ def param2dict(fname, db=True, **kwargs):
                         while "%endblock devel_code" not in flines[line_no + i].lower():
                             if i + line_no >= len(flines):
                                 raise RuntimeError("Found unclosed %block devel_code.")
-                            line = flines[line_no + i].lower()
+                            line = flines[line_no + i]
                             devel_lines.append(line_no + i)
                             if "devel_code" not in param:
                                 param["devel_code"] = ""

--- a/matador/scrapers/castep_scrapers.py
+++ b/matador/scrapers/castep_scrapers.py
@@ -694,7 +694,10 @@ def param2dict(fname, db=True, **kwargs):
                         while "%endblock devel_code" not in flines[line_no + i].lower():
                             if i + line_no >= len(flines):
                                 raise RuntimeError("Found unclosed %block devel_code.")
-                            line = flines[line_no + i].upper()
+                            if 'magres' in flines[line_no + i]:
+                                line = flines[line_no + i].upper()
+                            else:
+                                line = flines[line_no + i].lower()
                             devel_lines.append(line_no + i)
                             if "devel_code" not in param:
                                 param["devel_code"] = ""

--- a/matador/scrapers/castep_scrapers.py
+++ b/matador/scrapers/castep_scrapers.py
@@ -694,7 +694,7 @@ def param2dict(fname, db=True, **kwargs):
                         while "%endblock devel_code" not in flines[line_no + i].lower():
                             if i + line_no >= len(flines):
                                 raise RuntimeError("Found unclosed %block devel_code.")
-                            if "magres" in flines[line_no + i]:
+                            if "magres" in flines[line_no + i].lower():
                                 line = flines[line_no + i].upper()
                             else:
                                 line = flines[line_no + i].lower()

--- a/matador/scrapers/castep_scrapers.py
+++ b/matador/scrapers/castep_scrapers.py
@@ -694,7 +694,7 @@ def param2dict(fname, db=True, **kwargs):
                         while "%endblock devel_code" not in flines[line_no + i].lower():
                             if i + line_no >= len(flines):
                                 raise RuntimeError("Found unclosed %block devel_code.")
-                            line = flines[line_no + i]
+                            line = flines[line_no + i].upper()
                             devel_lines.append(line_no + i)
                             if "devel_code" not in param:
                                 param["devel_code"] = ""

--- a/matador/workflows/castep/magres.py
+++ b/matador/workflows/castep/magres.py
@@ -150,6 +150,7 @@ class CastepMagresWorkflow(Workflow):
 
         # prepare to do pre-relax if there's no check file
         if os.path.isfile(self.seed + ".check"):
+            todo["scf"] = False
             todo["relax"] = False
             LOG.info(
                 "Restarting from {}.check, so not performing re-relaxation".format(
@@ -207,7 +208,7 @@ def castep_magres(computer, calc_doc, seed, elec_energy_tol=1e-11):
         seed (str): root filename of structure.
 
     """
-    LOG.info("Performing CASTEP phonon dispersion calculation...")
+    LOG.info("Performing CASTEP Magres calculation...")
     magres_doc = copy.deepcopy(calc_doc)
     magres_doc["task"] = "magres"
     magres_doc["magres_task"] = calc_doc.get("magres_task", "NMR")

--- a/matador/workflows/castep/magres.py
+++ b/matador/workflows/castep/magres.py
@@ -150,7 +150,7 @@ class CastepMagresWorkflow(Workflow):
 
         # prepare to do pre-relax if there's no check file
         if os.path.isfile(self.seed + ".check"):
-            todo["scf"] = False
+            todo["scf"] = True
             todo["relax"] = False
             LOG.info(
                 "Restarting from {}.check, so not performing re-relaxation".format(


### PR DESCRIPTION
This branch contains minor changes to allow the MagresWorkflow to work with the restart commands in a .param file for a `task : magres` restart. Importantly, at least as recently as CASTEP v22.1, this block has to be written in uppercase, so I have modified the  `compute.py` script to write this block out in `.upper()` rather than `.lower()`. 

This branch also has the following changes to the logic of the Workflow task:
- if a .check file is present in the folder, don't perform `task['scf']` 
- if `<seed>.*.mag` files are present at the start of the calculation move them to `compute_dir` because these are required to restart the `magres` calculation
- Fix typo in `magres.py` that wrote `Starting Phonon calculation` to say `Starting Magres calculation`

This is the format of the block that should be written in the .param file if you want to restart a `task : magres` calculation.
```
%block devel_code 
MAGRES_RESTART MAGRES_RESTART_QPT
%endblock devel_code
```

