### PR TITLE
Constrained stress

### DIFF
--- a/matador/scrapers/castep_scrapers.py
+++ b/matador/scrapers/castep_scrapers.py
@@ -2001,7 +2001,6 @@ def _castep_scrape_final_structure(flines, castep, db=True):
         castep["kpoints_mp_spacing"] = calc_mp_spacing(
             castep["lattice_cart"], castep["kpoints_mp_grid"], prec=4
         )
-
     return castep
 
 

--- a/matador/scrapers/castep_scrapers.py
+++ b/matador/scrapers/castep_scrapers.py
@@ -1905,12 +1905,16 @@ def _castep_scrape_final_structure(flines, castep, db=True):
                 np.linalg.norm(castep["forces"], axis=-1)
             )
         elif "Stress Tensor" in line:
+            if 'Constrained' in line:
+                stress_key = "constrained_stress"
+            else:
+                stress_key = "stress"
             i = 1
             while i < 20:
                 if "Cartesian components" in final_flines[line_no + i]:
-                    castep["stress"] = []
+                    castep[stress_key] = []
                     for j in range(3):
-                        castep["stress"].append(
+                        castep[stress_key].append(
                             list(
                                 map(
                                     f90_float_parse,
@@ -1997,6 +2001,7 @@ def _castep_scrape_final_structure(flines, castep, db=True):
         castep["kpoints_mp_spacing"] = calc_mp_spacing(
             castep["lattice_cart"], castep["kpoints_mp_grid"], prec=4
         )
+
     return castep
 
 
@@ -2248,12 +2253,16 @@ def _castep_scrape_all_snapshots(flines, intermediates=False):
                         i += 1
                     snapshot["max_force_on_atom"] = pow(max_force, 0.5)
                 elif "Stress Tensor" in line:
+                    if 'Constrained' in line:
+                        stress_key = "constrained_stress"
+                    else:
+                        stress_key = "stress"
                     i = 1
                     while i < 20:
                         if "Cartesian components" in flines[line_no + i]:
-                            snapshot["stress"] = []
+                            snapshot[stress_key] = []
                             for j in range(3):
-                                snapshot["stress"].append(
+                                snapshot[stress_key].append(
                                     list(
                                         map(
                                             f90_float_parse,


### PR DESCRIPTION
Previously, castep2dict returned the constrained_stress as 'stress' and ignored the complete stress tensor.
The complete stress tensor is now returned as 'stress' and the constrained as 'constrained_stress'.