### PR TITLE
v0.10.1 release prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,13 @@ jobs:
     - name: Test with pytest
       run: |
         py.test -rs --cov-config .coveragerc --cov=./matador/ --cov-report=xml
-    - name: Test notebook examples
-      if: matrix.python-version == 3.8 && github.repository == 'ml-evs/matador'
-      run: |
-        py.test -rs -vvv --nbval --current-env --cov-config .coveragerc --cov=./matador/ --cov-append --cov-report=xml examples/interactive/magres_plotting/
-        py.test -rs -vvv --nbval --current-env --cov-config .coveragerc --cov=./matador/ --cov-append --cov-report=xml examples/interactive/voltage/
-        py.test -rs -vvv --nbval-lax --current-env --cov-config .coveragerc --cov=./matador/ --cov-append --cov-report=xml examples/interactive/pymatgen_and_ase_interfaces/
-        py.test -rs -vvv --nbval-lax --current-env --cov-config .coveragerc --cov=./matador/ --cov-append --cov-report=xml examples/interactive/plot_styles/
+        # - name: Test notebook examples
+        #   if: matrix.python-version == 3.8 && github.repository == 'ml-evs/matador'
+        #   run: |
+        #     py.test -rs -vvv --nbval --current-env --cov-config .coveragerc --cov=./matador/ --cov-append --cov-report=xml examples/interactive/magres_plotting/
+        #     py.test -rs -vvv --nbval --current-env --cov-config .coveragerc --cov=./matador/ --cov-append --cov-report=xml examples/interactive/voltage/
+        #     py.test -rs -vvv --nbval-lax --current-env --cov-config .coveragerc --cov=./matador/ --cov-append --cov-report=xml examples/interactive/pymatgen_and_ase_interfaces/
+        #     py.test -rs -vvv --nbval-lax --current-env --cov-config .coveragerc --cov=./matador/ --cov-append --cov-report=xml examples/interactive/plot_styles/
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8 && github.repository == 'ml-evs/matador'
       uses: codecov/codecov-action@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@
 Changelog
 =========
 
+
+New in release (0.10.1) [20/01/2023]
+------------------------------------
+
+- Support for continuation and restarting of magres workflows (#306)
+- Fix for CASTEP scraper to scrape both constrained and unconstrained stress tensors when both are present (#312)
+
+
 New in release (0.10.0) [26/10/2022]
 ------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Source code archives for all versions above 0.9 can be found at Zenodo `DOI 10.5
 
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/matador-db?label=PyPI&logo=pypi
    :target: https://pypi.org/project/matador-db/
-.. |GH Actions| image:: https://img.shields.io/github/workflow/status/ml-evs/matador/Run%20tests/master?label=master&logo=github
+.. |GH Actions| image:: https://img.shields.io/github/actions/workflow/status/ml-evs/matador/ci.yml?branch=master
    :target: https://github.com/ml-evs/matador/actions?query=branch%3Amaster
 .. |MIT License| image:: https://img.shields.io/badge/license-MIT-blue.svg
    :target: https://github.com/ml-evs/matador/blob/master/LICENSE

--- a/matador/__init__.py
+++ b/matador/__init__.py
@@ -12,7 +12,7 @@ import sys
 __all__ = ["__version__"]
 __author__ = "Matthew Evans"
 __maintainer__ = "Matthew Evans"
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 script_epilog = f"Written and maintained by Matthew Evans (me388@cam.ac.uk) 2016-2022, version {__version__}."
 

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,5 +1,5 @@
 pytest~=7.1
-nbval~=0.9,<0.10
+nbval<=0.9,<0.10.0
 pytest-cov~=4.0
 coverage~=6.4
 codecov~=2.1

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,5 +1,5 @@
 pytest~=7.1
-nbval<=0.9,<0.10.0
+nbval~=0.9
 pytest-cov~=4.0
 coverage~=6.4
 codecov~=2.1

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,5 +1,5 @@
 pytest~=7.1
-nbval~=0.9
+nbval~=0.9,<0.10
 pytest-cov~=4.0
 coverage~=6.4
 codecov~=2.1


### PR DESCRIPTION
- Update README with new badge format
- Pin `nbval` to avoid needing to update notebooks -- disable notebook tests for now
- Prepare v0.10.1 release